### PR TITLE
Expose client functionality to class level SupportBee

### DIFF
--- a/lib/support_bee.rb
+++ b/lib/support_bee.rb
@@ -1,6 +1,12 @@
 require "support_bee/version"
-require "support_bee/client"
 require "support_bee/error"
+require "support_bee/configuration"
+require "support_bee/client_interface"
+require "support_bee/client"
 
 module SupportBee
+  class << self
+    include SupportBee::Configuration
+    include SupportBee::ClientInterface
+  end
 end

--- a/lib/support_bee/client.rb
+++ b/lib/support_bee/client.rb
@@ -3,73 +3,14 @@ require 'hashie'
 
 module SupportBee
   class Client
-    attr_reader :auth_token, :base_url
+    include SupportBee::Configuration
+    include SupportBee::ClientInterface
 
     def initialize(options)
-      @auth_token = options[:auth_token]
-      @base_url = "https://#{options[:company]}.supportbee.com/"
-    end
-
-    def ticket(id)
-      url = build_url("tickets/#{ id }?auth_token=#{ auth_token }")
-
-      RestClient.get(url) do |response, request, result, &block|
-        case response.code
-        when 200
-          format_response(parse_json(response)).ticket
-        when 404
-          raise SupportBee::NotFound.new(response.body)
-        else
-          response.return!(request, result, &block)
-        end
+      configure do |config|
+        config.company = options[:company]
+        config.auth_token = options[:auth_token]
       end
     end
-
-    def create_ticket(params)
-      RestClient.post(build_url('tickets'), { ticket: params }, build_headers) do |response, request, result, &block|
-        case response.code
-        when 201
-          format_response(parse_json(response)).ticket
-        when 400
-          raise SupportBee::BadRequest.new(response.body)
-        else
-          response.return!(request, result, &block)
-        end
-      end
-    end
-
-    def add_label(ticket_id, label)
-      url = build_url("tickets/#{ ticket_id }/labels/#{ label }?auth_token=#{ auth_token }")
-
-      RestClient.post(url, {}, build_headers) do |response, request, result, &block|
-        case response.code
-        when 201
-          format_response(parse_json(response)).label
-        when 404
-          raise SupportBee::NotFound.new(response.body)
-        else
-          response.return!(request, result, &block)
-        end
-      end
-    end
-
-    private
-
-    def build_url(endpoint)
-      @base_url + endpoint
-    end
-
-    def format_response(parsed_json)
-      Hashie::Mash.new(parsed_json)
-    end
-
-    def parse_json(json)
-      JSON.parse(json)
-    end
-
-    def build_headers(headers={})
-      { content_type: :json, accept: :json }.merge(headers)
-    end
-
   end
 end

--- a/lib/support_bee/client_interface.rb
+++ b/lib/support_bee/client_interface.rb
@@ -1,0 +1,65 @@
+module SupportBee
+  module ClientInterface
+
+    def ticket(id)
+      url = build_url("tickets/#{ id }?auth_token=#{ auth_token }")
+
+      RestClient.get(url) do |response, request, result, &block|
+        case response.code
+        when 200
+          format_response(parse_json(response)).ticket
+        when 404
+          raise SupportBee::NotFound.new(response.body)
+        else
+          response.return!(request, result, &block)
+        end
+      end
+    end
+
+    def create_ticket(params)
+      RestClient.post(build_url('tickets'), { ticket: params }, build_headers) do |response, request, result, &block|
+        case response.code
+        when 201
+          format_response(parse_json(response)).ticket
+        when 400
+          raise SupportBee::BadRequest.new(response.body)
+        else
+          response.return!(request, result, &block)
+        end
+      end
+    end
+
+    def add_label(ticket_id, label)
+      url = build_url("tickets/#{ ticket_id }/labels/#{ label }?auth_token=#{ auth_token }")
+
+      RestClient.post(url, {}, build_headers) do |response, request, result, &block|
+        case response.code
+        when 201
+          format_response(parse_json(response)).label
+        when 404
+          raise SupportBee::NotFound.new(response.body)
+        else
+          response.return!(request, result, &block)
+        end
+      end
+    end
+
+    private
+
+    def build_url(endpoint)
+      "https://#{company}.supportbee.com/" + endpoint
+    end
+
+    def format_response(parsed_json)
+      Hashie::Mash.new(parsed_json)
+    end
+
+    def parse_json(json)
+      JSON.parse(json)
+    end
+
+    def build_headers(headers={})
+      { content_type: :json, accept: :json }.merge(headers)
+    end
+  end
+end

--- a/lib/support_bee/configuration.rb
+++ b/lib/support_bee/configuration.rb
@@ -1,0 +1,9 @@
+module SupportBee
+  module Configuration
+    attr_accessor :auth_token, :company
+
+    def configure
+      yield self
+    end
+  end
+end

--- a/spec/support_bee_spec.rb
+++ b/spec/support_bee_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+describe SupportBee do
+  before do
+    SupportBee.configure do |config|
+      config.company = 'gobiasindustries'
+      config.auth_token = 'abc123'
+    end
+  end
+
+  describe "creating a ticket" do
+    context "when successful" do
+      it "returns a formatted ticket" do
+        stub_request(:post, "https://gobiasindustries.supportbee.com/tickets")
+          .to_return(status: 201, body: SupportBee::Stubs["ticket"])
+
+        ticket = SupportBee.create_ticket({
+          subject: "Where are my hard-boiled eggs?",
+          requester_name: "Tobias Funke",
+          requester_email: "tobiasfunke@example.com",
+          content: {
+            text: "My eggs are no longer in the fridge."
+          }
+        })
+
+        expect(ticket.id).to eql(4784806)
+        expect(ticket.subject).to eql("Where are my hard-boiled eggs?")
+        expect(ticket.requester.name).to eql("Tobias Funke")
+        expect(ticket.requester.email).to eql("tobiasfunke@example.com")
+        expect(ticket.content.text).to eql("My eggs are no longer in the fridge.")
+        expect(ticket.content.html).to eql("My eggs are no longer in the fridge.")
+      end
+    end
+
+
+    context "when validation fails" do
+      it "raises SupportBee::BadRequest" do
+        stub_request(:post, "https://gobiasindustries.supportbee.com/tickets")
+          .to_return(status: 400, body: <<-RESP
+            {
+              "error": "Validation failed: Requester can't be blank, Requester can't be blank, Requester email can't be blank, Requester email email is invalid"
+            }
+          RESP
+        )
+
+        # without required `requester_email` field
+        ticket = {
+          subject: "Where are my hard-boiled eggs?",
+          requester_name: "Tobias Funke",
+          content: {
+            text: "My eggs are no longer in the fridge."
+          }
+        }
+
+        expect { SupportBee.create_ticket(ticket) }.to raise_error(SupportBee::BadRequest)
+      end
+    end
+  end
+
+  describe "fetching a ticket" do
+    context "when successful" do
+      it "returns a formatted ticket" do
+        stub_request(:get, "https://gobiasindustries.supportbee.com/tickets/4784806")
+          .with(query: { auth_token: "abc123" })
+          .to_return(status: 200, body: SupportBee::Stubs["ticket"])
+
+        ticket = SupportBee.ticket(4784806)
+
+        expect(ticket.id).to eql(4784806)
+        expect(ticket.subject).to eql("Where are my hard-boiled eggs?")
+        expect(ticket.requester.name).to eql("Tobias Funke")
+        expect(ticket.requester.email).to eql("tobiasfunke@example.com")
+        expect(ticket.content.text).to eql("My eggs are no longer in the fridge.")
+        expect(ticket.content.html).to eql("My eggs are no longer in the fridge.")
+      end
+    end
+
+    context "when ticket doesn't exit" do
+      it "raises SupportBee::NotFound" do
+        stub_request(:get, "https://gobiasindustries.supportbee.com/tickets/4784985")
+          .with(query: { auth_token: "abc123" })
+          .to_return(status: 404, body: <<-RESP
+            {"error":"Couldn't find Ticket with id=4784985 [WHERE \"tickets\".\"company_id\" = 5]"}
+          RESP
+          )
+
+        expect { SupportBee.ticket(4784985) }.to raise_error(SupportBee::NotFound)
+      end
+    end
+  end
+
+  describe "label requests" do
+    context "when successful" do
+      it "can create a label" do
+        stub_request(:post, "https://gobiasindustries.supportbee.com/tickets/4784985/labels/important")
+          .with(query: { auth_token: "abc123" })
+          .to_return(status: 201, body: SupportBee::Stubs["label"])
+
+        label = SupportBee.add_label(4784985, "important")
+
+        expect(label.id).to eql(9839577)
+        expect(label.label).to eql("important")
+        expect(label.ticket).to eql(4784985)
+      end
+    end
+
+    context "when label doesn't exist" do
+      it "raises SupportBee::NotFound" do
+        stub_request(:post, "https://gobiasindustries.supportbee.com/tickets/4784985/labels/non-existent-label")
+          .with(query: { auth_token: "abc123" })
+          .to_return(status: 404)
+
+        expect { SupportBee.add_label(4784985, "non-existent-label") }.to raise_error(SupportBee::NotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Tests are duplicated at the moment.

```
$ rspec

SupportBee::Client
  creating a ticket
    when successful
      returns a formatted ticket
    when validation fails
      raises SupportBee::BadRequest
  fetching a ticket
    when successful
      returns a formatted ticket
    when ticket doesn't exit
      raises SupportBee::NotFound
  label requests
    when successful
      can create a label
    when label doesn't exist
      raises SupportBee::NotFound

SupportBee
  creating a ticket
    when successful
      returns a formatted ticket
    when validation fails
      raises SupportBee::BadRequest
  fetching a ticket
    when successful
      returns a formatted ticket
    when ticket doesn't exit
      raises SupportBee::NotFound
  label requests
    when successful
      can create a label
    when label doesn't exist
      raises SupportBee::NotFound

Finished in 0.19806 seconds (files took 0.80193 seconds to load)
12 examples, 0 failures
```
